### PR TITLE
Add AGENTS.md with development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a static portfolio website (HTML/CSS/JS) with no build step, no package manager, and no dependencies to install.
+
+### Running the dev server
+
+Serve the site locally with Python's built-in HTTP server on port 5501 (matching `.vscode/settings.json` Live Server config):
+
+```
+python3 -m http.server 5501 --directory /workspace
+```
+
+Then open `http://localhost:5501/` in Chrome.
+
+### Project structure
+
+- `index.html` — single-page portfolio (all content)
+- `style.css` — all styles
+- `script.js` — client-side JS (animations, dark mode toggle, contact form)
+- `assets/` — fonts and images
+- `img/` — profile/headshot images
+- `_private/script.gs` — Google Apps Script backend for the contact form (deployed externally, not run locally)
+
+### Key notes
+
+- There is **no `package.json`**, no npm/yarn/pnpm, no build tools, no test framework, and no linter configured in this repo.
+- CDN-loaded libraries (jQuery, Typed.js, Font Awesome) require internet access for full functionality.
+- The contact form submits to an external Google Apps Script endpoint and uses reCAPTCHA v3; form submission cannot be tested locally without those external services.
+- Google Analytics is loaded but non-functional in local dev (expected).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for this static portfolio website.

### What's included

- Dev server setup instructions (Python HTTP server on port 5501)
- Project structure overview
- Key notes about external dependencies (CDN libraries, Google Apps Script, reCAPTCHA)

### Demo

[demo_portfolio_dark_mode_and_form.mp4](https://cursor.com/agents/bc-3d142090-678c-47fe-b230-22a129c84f20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_portfolio_dark_mode_and_form.mp4)

Theme toggle (light mode):
[Light mode](https://cursor.com/agents/bc-3d142090-678c-47fe-b230-22a129c84f20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_light_mode.webp)

Theme toggle (dark mode):
[Dark mode](https://cursor.com/agents/bc-3d142090-678c-47fe-b230-22a129c84f20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_dark_mode.webp)

Contact form interaction:
[Contact form filled](https://cursor.com/agents/bc-3d142090-678c-47fe-b230-22a129c84f20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_contact_form_filled.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d142090-678c-47fe-b230-22a129c84f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d142090-678c-47fe-b230-22a129c84f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

