### PR TITLE
Fix education section visibility after hiding IIT BHU logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,14 +322,15 @@
 
 								</a>
 							</div>
+						</div>
+						<!-- IIT BHU logo hidden per QUA-7 -->
+						<!-- <picture class="education-img">
+							<img loading="lazy" src="assets/images/work/iit_logo_original.png" alt="IIT BHU Homepage" />
+						</picture> -->
 					</div>
-					<!-- IIT BHU logo hidden per QUA-7 -->
-					<!-- <picture class="education-img">
-						<img loading="lazy" src="assets/images/work/iit_logo_original.png" alt="IIT BHU Homepage" />
-					</picture> -->
 				</div>
 			</div>
-	</section>
+		</section>
 
 
 

--- a/script.js
+++ b/script.js
@@ -80,7 +80,9 @@ let educobserver = new IntersectionObserver(
     const [entry] = entries;
     const [textbox, picture] = Array.from(entry.target.children);
     if (entry.isIntersecting) {
-      picture.classList.remove("transform");
+      if (picture) {
+        picture.classList.remove("transform");
+      }
       Array.from(textbox.children).forEach(
         (el) => (el.style.animationPlayState = "running")
       );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the education section visibility issue that was introduced when the IIT BHU logo was hidden in PR #6.

## Problem

After the IIT BHU logo was commented out in `index.html`, the education section content (institution name, degree, years, achievements, link) became invisible. Only the "Education" heading was displayed.

## Root Cause

Two issues were causing this:

1. **Broken HTML structure**: The original code had improperly nested `</div>` tags. When the `<picture>` element was commented out, the HTML nesting became malformed, causing the browser to fail rendering the content properly.

2. **JavaScript error**: The IntersectionObserver for the education section assumed there would always be a `picture` element as the second child. When `picture` was `undefined` (because it was commented out), calling `picture.classList.remove("transform")` threw an error. This prevented the slide-up animation from running, leaving the content with `opacity: 0`.

## Changes

- **`index.html`**: Fixed the HTML structure with proper closing `</div>` tags for `education-textbox`, `education-box`, and `education-boxes`
- **`script.js`**: Added null check for `picture` element in the `educobserver` callback

## Testing

Verified the fix by running the local dev server and confirming the education section now displays all content correctly.

[Education section with all content visible](https://cursor.com/agents/bc-a25cdbbd-e5a1-4b29-82cf-a8c5ebed50ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feducation_section_fixed.webp)

[education_section_visible_demo.mp4](https://cursor.com/agents/bc-a25cdbbd-e5a1-4b29-82cf-a8c5ebed50ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feducation_section_visible_demo.mp4)

## Related

- Fixes the issue reported after PR #6 (`cursor/remove-iit-bhu-logo-4502`)
- Linear issue: QUA-7

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [QUA-7](https://linear.app/quantum-monks/issue/QUA-7/remove-the-iit-bhu-logo-from-home-page)

<div><a href="https://cursor.com/agents/bc-a25cdbbd-e5a1-4b29-82cf-a8c5ebed50ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a25cdbbd-e5a1-4b29-82cf-a8c5ebed50ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

